### PR TITLE
Fix vllm multi-gpu support

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -156,8 +156,14 @@ class LLMEngine:
         return self.tokenizer.get_lora_tokenizer(sequence.lora_request)
 
     def _dispatch_worker(self):
+        device_type = "neuron"
+        if "cuda" not in self.device_config.device_type:
+            device_type = "neuron"
+        # "cuda" in self.device_config.device_type
+        else:
+            device_type = "cuda"
         worker_module = DEVICE_TO_WORKER_MODULE_MAP[
-            self.device_config.device_type]
+            device_type]
         imported_worker = importlib.import_module(worker_module)
         Worker = imported_worker.Worker
         return Worker

--- a/vllm/model_executor/utils.py
+++ b/vllm/model_executor/utils.py
@@ -45,7 +45,13 @@ def set_weight_attrs(
 
 def get_model(model_config: ModelConfig, device_config: DeviceConfig,
               **kwargs) -> torch.nn.Module:
-    model_loader_module = DEVICE_TO_MODEL_LOADER_MAP[device_config.device_type]
+    device_type = "neuron"
+    if "cuda" not in device_config.device_type:
+        device_type = "neuron"
+    else:
+        device_type = "cuda"
+        
+    model_loader_module = DEVICE_TO_MODEL_LOADER_MAP[device_type]
     imported_model_loader = importlib.import_module(
         f"vllm.model_executor.{model_loader_module}")
     get_model_fn = imported_model_loader.get_model


### PR DESCRIPTION
Add multi-gpu support to vllm, now vllm can be launched on different device, we need to specify both "local_rank" and "device" when initing `LLM`