### PR TITLE
Fix import error for the outlines function build_regex_from_schema

### DIFF
--- a/vllm/model_executor/guided_decoding/outlines_logits_processors.py
+++ b/vllm/model_executor/guided_decoding/outlines_logits_processors.py
@@ -22,7 +22,7 @@ from typing import Callable, DefaultDict, Dict, List, Union
 
 import torch
 from outlines.fsm.guide import CFGGuide, Generate, Guide, RegexGuide, Write
-from outlines.fsm.json_schema import build_regex_from_schema
+from outlines_core.fsm.json_schema import build_regex_from_schema
 from pydantic import BaseModel
 from transformers import PreTrainedTokenizerBase
 


### PR DESCRIPTION
Fixes an `ImportError: cannot import name 'build_regex_from_schema' from 'outlines.fsm.json_schema' `.

With the latest release of the `outlines` pip package, the function `build_regex_from_schema` is now in `outlines_core.fsm.json_schema`, not `outlines.fsm.json_schema`. [See here](https://github.com/dottxt-ai/outlines/commit/1b7ec18a91b6d39e0279dd91cfe9bab415dc80c4).